### PR TITLE
Update symfony/http-foundation requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: php
+dist: bionic
 
 php:
-  - 5.6
-  - 5.5
-  - 5.4
-  - hhvm
-  - hhvm-nightly
+  - 7.1
+  - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: hhvm
-    - php: hhvm-nightly
 
 install:
   - composer install --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "peridot-php/leo": "~1.0",
-        "symfony/http-foundation": "~2.0"
+        "symfony/http-foundation": "~2.0|~3.0|~4.0"
     },
     "require-dev": {
         "peridot-php/peridot-jumpstart": "~1.0"


### PR DESCRIPTION
Allow HttpFoundation 2.x, 3.x, or 4.x. Update Travis to remove EOL versions of PHP